### PR TITLE
公开 ReplyChain 内的属性

### DIFF
--- a/Konata.Core/Message/Model/ReplyChain.cs
+++ b/Konata.Core/Message/Model/ReplyChain.cs
@@ -11,27 +11,27 @@ public class ReplyChain : BaseChain
     /// <summary>
     /// Reply uin
     /// </summary>
-    internal uint Uin { get; }
+    public uint Uin { get; }
 
     /// <summary>
     /// Sequence of reply message
     /// </summary>
-    internal uint Sequence { get; }
+    public uint Sequence { get; }
 
     /// <summary>
     /// Uuid of reply message
     /// </summary>
-    internal long Uuid { get; }
+    public long Uuid { get; }
 
     /// <summary>
     /// Time of reply message
     /// </summary>
-    internal uint Time { get; }
+    public uint Time { get; }
 
     /// <summary>
     /// Reply message preview
     /// </summary>
-    internal string Preview { get; }
+    public string Preview { get; }
 
     private ReplyChain(uint uin, uint sequence, long uuid, uint time, string preview)
         : base(ChainType.Reply, ChainMode.Singletag)


### PR DESCRIPTION
将 `ReplyChain` 内的一些用于定位消息的属性由 `internal` 改为 `public` 

此前它们对外部程序集是不可见的，公开后可以方便开发者自行实现消息上下文定位