### PR TITLE
fix: wrong img detect result

### DIFF
--- a/Konata.Core.Test/UtilTest/DetectImageTest.cs
+++ b/Konata.Core.Test/UtilTest/DetectImageTest.cs
@@ -1,0 +1,21 @@
+using System.Net.Http;
+using System.Threading.Tasks;
+using Konata.Core.Utils.FileFormat;
+using NUnit.Framework;
+
+namespace Konata.Core.Test.UtilTest;
+
+public class DetectImageTest
+{
+    [Test]
+    public async Task TestDetectImage()
+    {
+        var c = new HttpClient();
+        var bs = await c.GetByteArrayAsync("https://cdn.mo2.leezeeyee.com/6" +
+            "03ba0e2dfacf44803d8c780/1659593390232351509image.png~thumb");
+        var r = FileFormat.DetectImage(bs, out var type, out var w, out var h);
+        Assert.AreEqual(type, FileFormat.ImageFormat.Webp);
+        Assert.AreEqual(w, 304);
+        Assert.AreEqual(h, 131);
+    }
+}

--- a/Konata.Core/Utils/FileFormat/DetectImage.cs
+++ b/Konata.Core/Utils/FileFormat/DetectImage.cs
@@ -155,10 +155,10 @@ internal static partial class FileFormat
     private static bool DetectWebp(ByteBuffer buffer,
         out uint width, out uint height)
     {
-        buffer.PeekUshortLE(0x1A, out var w);
-        width = w;
-        buffer.PeekUshortLE(0x1C, out var h);
-        height = h;
+        buffer.PeekUshortLE(0x18, out var w);
+        width = w + (uint)1;
+        buffer.PeekUshortLE(0x1B, out var h);
+        height = h + (uint)1;
         return true;
     }
 }


### PR DESCRIPTION
fixed #177 

- 增加相关测试用例
- 使用ImageSharp来获取图像信息