### PR TITLE
(ci/workflow) update github workflow deps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,11 +12,11 @@ jobs:
 
     # Checkout
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     
     # Setup
     - name: Setup Build
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
     
     # Restore packages
     - name: Restore dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,11 +12,11 @@ jobs:
 
     # Checkout
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     
     # Setup
     - name: Setup Test
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
     
     # Restore packages
     - name: Restore dependencies


### PR DESCRIPTION
GitHub workflow says that actions use Node.js version 12 are deprecated.

https://github.com/KonataDev/Konata.Core/actions/runs/4530528354

https://github.com/KonataDev/Konata.Core/actions/runs/4461904169

updated the workflow dependency to eliminate the warning